### PR TITLE
Add polyfills for `OSPlatformAttribute` and its derivatives

### DIFF
--- a/PolyShim/Net50/OSPlatformAttribute.cs
+++ b/PolyShim/Net50/OSPlatformAttribute.cs
@@ -1,0 +1,18 @@
+﻿#if (NETCOREAPP && !NET5_0_OR_GREATER) || (NETFRAMEWORK) || (NETSTANDARD)
+#nullable enable
+// ReSharper disable RedundantUsingDirective
+// ReSharper disable CheckNamespace
+// ReSharper disable InconsistentNaming
+// ReSharper disable PartialTypeWithSinglePart
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.Versioning;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.osplatformattribute
+[ExcludeFromCodeCoverage]
+internal abstract class OSPlatformAttribute(string platformName) : Attribute
+{
+    public string PlatformName { get; } = platformName;
+}
+#endif

--- a/PolyShim/Net50/SupportedOSPlatformAttribute.cs
+++ b/PolyShim/Net50/SupportedOSPlatformAttribute.cs
@@ -1,0 +1,31 @@
+﻿#if (NETCOREAPP && !NET5_0_OR_GREATER) || (NETFRAMEWORK) || (NETSTANDARD)
+#nullable enable
+// ReSharper disable RedundantUsingDirective
+// ReSharper disable CheckNamespace
+// ReSharper disable InconsistentNaming
+// ReSharper disable PartialTypeWithSinglePart
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.Versioning;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.supportedosplatformattribute
+[AttributeUsage(
+    AttributeTargets.Assembly
+        | AttributeTargets.Class
+        | AttributeTargets.Constructor
+        | AttributeTargets.Enum
+        | AttributeTargets.Event
+        | AttributeTargets.Field
+        | AttributeTargets.Interface
+        | AttributeTargets.Method
+        | AttributeTargets.Module
+        | AttributeTargets.Property
+        | AttributeTargets.Struct,
+    AllowMultiple = true,
+    Inherited = false
+)]
+[ExcludeFromCodeCoverage]
+internal class SupportedOSPlatformAttribute(string platformName)
+    : OSPlatformAttribute(platformName);
+#endif

--- a/PolyShim/Net50/TargetPlatformAttribute.cs
+++ b/PolyShim/Net50/TargetPlatformAttribute.cs
@@ -1,0 +1,16 @@
+﻿#if (NETCOREAPP && !NET5_0_OR_GREATER) || (NETFRAMEWORK) || (NETSTANDARD)
+#nullable enable
+// ReSharper disable RedundantUsingDirective
+// ReSharper disable CheckNamespace
+// ReSharper disable InconsistentNaming
+// ReSharper disable PartialTypeWithSinglePart
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.Versioning;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.targetplatformattribute
+[AttributeUsage(AttributeTargets.Assembly)]
+[ExcludeFromCodeCoverage]
+internal class TargetPlatformAttribute(string platformName) : OSPlatformAttribute(platformName);
+#endif

--- a/PolyShim/Net50/UnsupportedOSPlatformAttribute.cs
+++ b/PolyShim/Net50/UnsupportedOSPlatformAttribute.cs
@@ -1,0 +1,34 @@
+﻿#if (NETCOREAPP && !NET5_0_OR_GREATER) || (NETFRAMEWORK) || (NETSTANDARD)
+#nullable enable
+// ReSharper disable RedundantUsingDirective
+// ReSharper disable CheckNamespace
+// ReSharper disable InconsistentNaming
+// ReSharper disable PartialTypeWithSinglePart
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.Versioning;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.unsupportedosplatformattribute
+[AttributeUsage(
+    AttributeTargets.Assembly
+        | AttributeTargets.Class
+        | AttributeTargets.Constructor
+        | AttributeTargets.Enum
+        | AttributeTargets.Event
+        | AttributeTargets.Field
+        | AttributeTargets.Interface
+        | AttributeTargets.Method
+        | AttributeTargets.Module
+        | AttributeTargets.Property
+        | AttributeTargets.Struct,
+    AllowMultiple = true,
+    Inherited = false
+)]
+[ExcludeFromCodeCoverage]
+internal class UnsupportedOSPlatformAttribute(string platformName, string? message = null)
+    : OSPlatformAttribute(platformName)
+{
+    public string? Message { get; } = message;
+}
+#endif

--- a/PolyShim/Net60/SupportedOSPlatformGuardAttribute.cs
+++ b/PolyShim/Net60/SupportedOSPlatformGuardAttribute.cs
@@ -1,0 +1,21 @@
+﻿#if (NETCOREAPP && !NET6_0_OR_GREATER) || (NETFRAMEWORK) || (NETSTANDARD)
+#nullable enable
+// ReSharper disable RedundantUsingDirective
+// ReSharper disable CheckNamespace
+// ReSharper disable InconsistentNaming
+// ReSharper disable PartialTypeWithSinglePart
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.Versioning;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.supportedosplatformguardattribute
+[AttributeUsage(
+    AttributeTargets.Field | AttributeTargets.Method | AttributeTargets.Property,
+    AllowMultiple = true,
+    Inherited = false
+)]
+[ExcludeFromCodeCoverage]
+internal class SupportedOSPlatformGuardAttribute(string platformName)
+    : OSPlatformAttribute(platformName);
+#endif

--- a/PolyShim/Net60/SupportedOSPlatformGuardAttribute.cs
+++ b/PolyShim/Net60/SupportedOSPlatformGuardAttribute.cs
@@ -17,10 +17,11 @@ namespace System.Runtime.Versioning;
 )]
 [ExcludeFromCodeCoverage]
 internal class SupportedOSPlatformGuardAttribute(string platformName)
-// OSPlatformAttribute's constructor is not accessible where that type is natively defined
+    // OSPlatformAttribute's constructor is not accessible where that type is natively defined
 #if !(NETCOREAPP && NET5_0_OR_GREATER)
     : OSPlatformAttribute(platformName);
 #else
+    : Attribute
 {
     public string PlatformName { get; } = platformName;
 }

--- a/PolyShim/Net60/SupportedOSPlatformGuardAttribute.cs
+++ b/PolyShim/Net60/SupportedOSPlatformGuardAttribute.cs
@@ -17,5 +17,12 @@ namespace System.Runtime.Versioning;
 )]
 [ExcludeFromCodeCoverage]
 internal class SupportedOSPlatformGuardAttribute(string platformName)
+// OSPlatformAttribute's constructor is not accessible where that type is natively defined
+#if !(NETCOREAPP && NET5_0_OR_GREATER)
     : OSPlatformAttribute(platformName);
+#else
+{
+    public string PlatformName { get; } = platformName;
+}
+#endif
 #endif

--- a/PolyShim/Net60/UnsupportedOSPlatformGuardAttribute.cs
+++ b/PolyShim/Net60/UnsupportedOSPlatformGuardAttribute.cs
@@ -1,0 +1,21 @@
+﻿#if (NETCOREAPP && !NET6_0_OR_GREATER) || (NETFRAMEWORK) || (NETSTANDARD)
+#nullable enable
+// ReSharper disable RedundantUsingDirective
+// ReSharper disable CheckNamespace
+// ReSharper disable InconsistentNaming
+// ReSharper disable PartialTypeWithSinglePart
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.Versioning;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.unsupportedosplatformguardattribute
+[AttributeUsage(
+    AttributeTargets.Field | AttributeTargets.Method | AttributeTargets.Property,
+    AllowMultiple = true,
+    Inherited = false
+)]
+[ExcludeFromCodeCoverage]
+internal class UnsupportedOSPlatformGuardAttribute(string platformName)
+    : OSPlatformAttribute(platformName);
+#endif

--- a/PolyShim/Net60/UnsupportedOSPlatformGuardAttribute.cs
+++ b/PolyShim/Net60/UnsupportedOSPlatformGuardAttribute.cs
@@ -17,5 +17,12 @@ namespace System.Runtime.Versioning;
 )]
 [ExcludeFromCodeCoverage]
 internal class UnsupportedOSPlatformGuardAttribute(string platformName)
+// OSPlatformAttribute's constructor is not accessible where that type is natively defined
+#if !(NETCOREAPP && NET5_0_OR_GREATER)
     : OSPlatformAttribute(platformName);
+#else
+{
+    public string PlatformName { get; } = platformName;
+}
+#endif
 #endif

--- a/PolyShim/Net60/UnsupportedOSPlatformGuardAttribute.cs
+++ b/PolyShim/Net60/UnsupportedOSPlatformGuardAttribute.cs
@@ -17,10 +17,11 @@ namespace System.Runtime.Versioning;
 )]
 [ExcludeFromCodeCoverage]
 internal class UnsupportedOSPlatformGuardAttribute(string platformName)
-// OSPlatformAttribute's constructor is not accessible where that type is natively defined
+    // OSPlatformAttribute's constructor is not accessible where that type is natively defined
 #if !(NETCOREAPP && NET5_0_OR_GREATER)
     : OSPlatformAttribute(platformName);
 #else
+    : Attribute
 {
     public string PlatformName { get; } = platformName;
 }

--- a/PolyShim/Net70/ObsoletedOSPlatformAttribute.cs
+++ b/PolyShim/Net70/ObsoletedOSPlatformAttribute.cs
@@ -27,14 +27,16 @@ namespace System.Runtime.Versioning;
 )]
 [ExcludeFromCodeCoverage]
 internal class ObsoletedOSPlatformAttribute(string platformName, string? message = null)
-// OSPlatformAttribute's constructor is not accessible where that type is natively defined
+    // OSPlatformAttribute's constructor is not accessible where that type is natively defined
 #if !(NETCOREAPP && NET5_0_OR_GREATER)
-    : OSPlatformAttribute(platformName);
+    : OSPlatformAttribute(platformName)
+#else
+    : Attribute
 #endif
 {
-    #if (NETCOREAPP && NET5_0_OR_GREATER)
+#if (NETCOREAPP && NET5_0_OR_GREATER)
     public string PlatformName { get; } = platformName;
-    #endif
+#endif
 
     public string? Message { get; } = message;
 

--- a/PolyShim/Net70/ObsoletedOSPlatformAttribute.cs
+++ b/PolyShim/Net70/ObsoletedOSPlatformAttribute.cs
@@ -27,8 +27,15 @@ namespace System.Runtime.Versioning;
 )]
 [ExcludeFromCodeCoverage]
 internal class ObsoletedOSPlatformAttribute(string platformName, string? message = null)
-    : OSPlatformAttribute(platformName)
+// OSPlatformAttribute's constructor is not accessible where that type is natively defined
+#if !(NETCOREAPP && NET5_0_OR_GREATER)
+    : OSPlatformAttribute(platformName);
+#endif
 {
+    #if (NETCOREAPP && NET5_0_OR_GREATER)
+    public string PlatformName { get; } = platformName;
+    #endif
+
     public string? Message { get; } = message;
 
     public string? Url { get; init; }

--- a/PolyShim/Net70/ObsoletedOSPlatformAttribute.cs
+++ b/PolyShim/Net70/ObsoletedOSPlatformAttribute.cs
@@ -1,0 +1,36 @@
+﻿#if (NETCOREAPP && !NET7_0_OR_GREATER) || (NETFRAMEWORK) || (NETSTANDARD)
+#nullable enable
+// ReSharper disable RedundantUsingDirective
+// ReSharper disable CheckNamespace
+// ReSharper disable InconsistentNaming
+// ReSharper disable PartialTypeWithSinglePart
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.Versioning;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.obsoletedosplatformattribute
+[AttributeUsage(
+    AttributeTargets.Assembly
+        | AttributeTargets.Class
+        | AttributeTargets.Constructor
+        | AttributeTargets.Enum
+        | AttributeTargets.Event
+        | AttributeTargets.Field
+        | AttributeTargets.Interface
+        | AttributeTargets.Method
+        | AttributeTargets.Module
+        | AttributeTargets.Property
+        | AttributeTargets.Struct,
+    AllowMultiple = true,
+    Inherited = false
+)]
+[ExcludeFromCodeCoverage]
+internal class ObsoletedOSPlatformAttribute(string platformName, string? message = null)
+    : OSPlatformAttribute(platformName)
+{
+    public string? Message { get; } = message;
+
+    public string? Url { get; init; }
+}
+#endif


### PR DESCRIPTION
Because `OSPlatformAttribute.ctor` is not accessible from other assemblies on .NET 5.0+ (where that type/ctor is defined natively), polyfills for attributes defined in .NET 6.0+ don't derive from that type.